### PR TITLE
Use spread operator to collect rest args

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -162,9 +162,7 @@ function internalEl(name, attributes, childrenArray, key, namespace) {
   return new VNode(name, finalAttrs, children, attrs.key, namespace);
 }
 
-export function el(tagName) {
-  let args = Array.slice(arguments);
-  args = args.slice(1);
+export function el(tagName, ...args) {
   let argsLength = args.length;
   let name = _.isString(tagName) ? (_.escape(tagName) || 'unknown') : tagName;
   // 1 args
@@ -227,8 +225,8 @@ export function el(tagName) {
   return internalEl(name, args[1], args[2], args[1].key, args[0]);
 }
 
-export function svg(name) {
-  return el.apply(null, [name, svgNS].concat(Array.slice(arguments).slice(1)));
+export function svg(name, ...args) {
+  return el.apply(null, [name, svgNS].concat(args));
 }
 
 export function nbsp(times) {

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ const _ = {
   isArray: require('lodash/lang/isArray'),
   isString: require('lodash/lang/isString'),
   isUndefined: require('lodash/lang/isUndefined'),
-  isNull: require('lodash/lang/isNull'),
+  isNull: (what) => Object.is(what, null), (// require('lodash/lang/isNull'),
   clone: (what) => ({...what}), // require('lodash/lang/clone'),
   escape: require('lodash/string/escape'),
   extend: Object.assign, // require('lodash/object/extend'),

--- a/src/utils.js
+++ b/src/utils.js
@@ -200,17 +200,15 @@ export function uuid() {
   });
 }
 
-export function invariant(condition, message) {
+export function invariant(condition, message, ...args) {
   if (!condition) {
-    let args = Array.slice(arguments).slice(2);
     let argIndex = 0;
     throw new Error('Violation : ' + message.replace(/%s/g, () => { return args[argIndex++]; }));
   }
 }
 
-export function invariantLog(condition, message) {
+export function invariantLog(condition, message, ...args) {
   if (!condition) {
-    let args = Array.slice(arguments).slice(2);
     let argIndex = 0;
     console.error('Violation : ' + message.replace(/%s/g, () => { return args[argIndex++]; }));
   }


### PR DESCRIPTION
It has the bonus advantage to avoid calls to Array.slice (not universal -> Array.prototype.slice)
I've also repaced lodash#isNull with Object.is(what, null)
